### PR TITLE
Improve the array comparison experience

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val scalaLibraryNext = crossProject(JVMPlatform, JSPlatform)
   .jvmSettings(
     libraryDependencies += "junit" % "junit" % "4.13.1" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test,
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v"),
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-s"),
   )
   .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,11 @@ lazy val scalaLibraryNext = crossProject(JVMPlatform, JSPlatform)
   .settings(
     ScalaModulePlugin.scalaModuleSettings,
     scalaModuleMimaPreviousVersion := None,
-    scalacOptions ++= Seq("-deprecation", "-feature", "-Werror"),
+    scalacOptions ++= Seq(
+      "-feature",
+      "-Werror",
+      "-Xlint",
+    ),
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % "1.15.1" % Test,
     ),

--- a/src/main/scala/next.scala
+++ b/src/main/scala/next.scala
@@ -1,0 +1,13 @@
+
+package scala
+
+object next {
+  implicit class NextArray[A <: AnyRef](private val as: Array[A]) extends AnyVal {
+    def sameElements[B <: AnyRef](bs: Array[B]): Boolean =
+      Array.equals(as.asInstanceOf[Array[AnyRef]], bs.asInstanceOf[Array[AnyRef]])
+  }
+  implicit class NextArrayCompanion(private val ary: Array.type) /*extends AnyVal*/ {
+    def equals[A <: AnyRef, B <: AnyRef](as: Array[A], bs: Array[B]): Boolean =
+      ary.equals(as.asInstanceOf[Array[AnyRef]], bs.asInstanceOf[Array[AnyRef]])
+  }
+}

--- a/src/main/scala/next.scala
+++ b/src/main/scala/next.scala
@@ -10,4 +10,15 @@ object next {
     def equals[A <: AnyRef, B <: AnyRef](as: Array[A], bs: Array[B]): Boolean =
       ary.equals(as.asInstanceOf[Array[AnyRef]], bs.asInstanceOf[Array[AnyRef]])
   }
+
+  implicit class NextRichByte(private val b: Byte) extends AnyVal {
+    def toBinaryString: String = java.lang.Integer.toBinaryString(java.lang.Byte.toUnsignedInt(b))
+    def toHexString: String    = java.lang.Integer.toHexString(java.lang.Byte.toUnsignedInt(b))
+    def toOctalString: String  = java.lang.Integer.toOctalString(java.lang.Byte.toUnsignedInt(b))
+  }
+  implicit class NextRichShort(private val s: Short) extends AnyVal {
+    def toBinaryString: String = java.lang.Integer.toBinaryString(java.lang.Short.toUnsignedInt(s))
+    def toHexString: String    = java.lang.Integer.toHexString(java.lang.Short.toUnsignedInt(s))
+    def toOctalString: String  = java.lang.Integer.toOctalString(java.lang.Short.toUnsignedInt(s))
+  }
 }

--- a/src/test/scala/scala/ArrayTest.scala
+++ b/src/test/scala/scala/ArrayTest.scala
@@ -1,0 +1,13 @@
+
+import org.junit.{Assert, Test}, Assert.{assertTrue}
+
+class ArrayTest {
+  import scala.next._
+
+  @Test def `compare arbitrary arrays`(): Unit = {
+    val xs = Array(List(1, 2, 3))
+    val ys = Array(Vector(1, 2, 3))
+    assertTrue(Array.equals(xs, ys))
+    assertTrue(xs.sameElements(ys))
+  }
+}

--- a/src/test/scala/scala/RicherTest.scala
+++ b/src/test/scala/scala/RicherTest.scala
@@ -1,0 +1,74 @@
+
+// test package because we are testing imports
+package scala.test
+
+import org.junit.{Assert, Test}
+
+class RicherTest {
+  import scala.next._
+  import RicherTest._
+
+  private def assertEqualTo(expected: String)(actual: String) = Assert.assertEquals(expected, actual)
+
+  @Test def `Byte expansions should be byte-sized`(): Unit = {
+    val sixteen = 16.toByte
+    assertEqualTo(x"1_0000")(sixteen.toBinaryString)
+    assertEqualTo("10")(sixteen.toHexString)
+    assertEqualTo("20")(sixteen.toOctalString)
+    val max = 0x7F.toByte
+    assertEqualTo(x"111_1111")(max.toBinaryString)
+    assertEqualTo("7f")(max.toHexString)
+    assertEqualTo("177")(max.toOctalString)
+    val extended = 0x80.toByte
+    assertEqualTo(x"1000_0000")(extended.toBinaryString)
+    assertEqualTo("80")(extended.toHexString)
+    assertEqualTo("200")(extended.toOctalString)
+    val neg = -1.toByte
+    assertEqualTo(x"1111_1111")(neg.toBinaryString)
+    assertEqualTo("ff")(neg.toHexString)
+    assertEqualTo("377")(neg.toOctalString)
+  }
+  @Test def `Short expansions should be short-sized`(): Unit = {
+    val sixteen = 16.toShort
+    assertEqualTo(x"1_0000")(sixteen.toBinaryString)
+    assertEqualTo("10")(sixteen.toHexString)
+    assertEqualTo("20")(sixteen.toOctalString)
+    val max = 0x7FFF.toShort
+    assertEqualTo(x"111_1111_1111_1111")(max.toBinaryString)
+    assertEqualTo("7fff")(max.toHexString)
+    assertEqualTo("77777")(max.toOctalString)
+    val extended = 0x8000.toShort
+    assertEqualTo(x"1000_0000_0000_0000")(extended.toBinaryString)
+    assertEqualTo("8000")(extended.toHexString)
+    assertEqualTo(x"10_0000")(extended.toOctalString)
+    val neg = -1.toShort
+    assertEqualTo("1" * 16)(neg.toBinaryString)
+    assertEqualTo("ffff")(neg.toHexString)
+    assertEqualTo(x"17_7777")(neg.toOctalString)
+  }
+  // same as short, but uses int conversion because unsigned
+  @Test def `Char expansions should be char-sized`(): Unit = {
+    val sixteen = 16.toChar
+    assertEqualTo(x"1_0000")(sixteen.toBinaryString)
+    assertEqualTo("10")(sixteen.toHexString)
+    assertEqualTo("20")(sixteen.toOctalString)
+    val max = 0x7FFF.toChar
+    assertEqualTo(x"111_1111_1111_1111")(max.toBinaryString)
+    assertEqualTo("7fff")(max.toHexString)
+    assertEqualTo("77777")(max.toOctalString)
+    val extended = 0x8000.toChar
+    assertEqualTo(x"1000_0000_0000_0000")(extended.toBinaryString)
+    assertEqualTo("8000")(extended.toHexString)
+    assertEqualTo(x"10_0000")(extended.toOctalString)
+    val neg = -1.toChar
+    assertEqualTo("1" * 16)(neg.toBinaryString)
+    assertEqualTo("ffff")(neg.toHexString)
+    assertEqualTo(x"17_7777")(neg.toOctalString)
+  }
+}
+
+object RicherTest {
+  implicit class stripper(private val sc: StringContext) extends AnyVal {
+    def x(args: Any*) = StringContext.standardInterpolator(_.replace("_", ""), args, sc.parts)
+  }
+}


### PR DESCRIPTION
This PR follows up two issues:

- a [comment](https://github.com/scala/scala/pull/9100#issuecomment-703740710) that `Array.equals(xs, ys)` is not convenient to use, as documented in the linked PR.
- an [issue](https://github.com/scala/bug/issues/10216) that `toHexString` sign-extends bytes because the API is on `Int`.

The issue with `toHexString` just came up on stackoverflow, so it's a thing.

This PR is also just to see how contributions here work. Also it looks like there is a JS issue.

