### PR TITLE
add `readWith` method to StdIn

### DIFF
--- a/src/main/scala/scala/io/next/package.scala
+++ b/src/main/scala/scala/io/next/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.io
+
+package object next {
+  implicit class NextStdInExtensions(si: StdIn) {
+    /** Reads and applying a function on an entire line of the default input .
+     *
+     *  @return the Byte that was read
+     *  @throws java.io.EOFException if the end of the
+     *  input stream has been reached.
+     */
+    def readWith[A](f: String => A): A = {
+      val s = si.readLine()
+      if (s == null)
+        throw new java.io.EOFException("Console has reached end of input")
+      else
+        f(s)
+    }
+  }
+}

--- a/src/test/scala/scala/io/TestStdInExtensions.scala
+++ b/src/test/scala/scala/io/TestStdInExtensions.scala
@@ -1,0 +1,47 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.io
+
+import next._
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+
+class TestStdInExtensions {
+  @Test
+  def readArray(): Unit = {
+    val in = new ByteArrayInputStream("1 2 3 4".getBytes)
+    Console.withIn(in) {
+      assertArrayEquals(
+        StdIn.readWith(input => input.split(" ").map(_.toInt)),
+        Array(1, 2, 3, 4))
+    }
+  }
+
+  @Test
+  def readClass(): Unit = {
+    case class Person(name: String, age: Int)
+    val in = new ByteArrayInputStream("John 34".getBytes)
+    Console.withIn(in) {
+      assertEquals(
+        StdIn.readWith(input => {
+          val Array(name, age) = input.split(" ")
+          Person(name, age.toInt)
+        }),
+        Person("John", 34))
+    }
+  }
+}


### PR DESCRIPTION
Inputs are very often parsed in order to get a desired object A. 
I think it would be convenient to add the method `StdIn.readWith[A](f: String => Boolean): A` to Scala in order to make the input processing phase more natural and thus gain in fluidity (chained methods for example).