### PR TITLE
Declare `versionScheme`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ lazy val scalaLibraryNext = crossProject(JVMPlatform, JSPlatform)
   .jsEnablePlugins(ScalaJSJUnitPlugin)
   .settings(
     ScalaModulePlugin.scalaModuleSettings,
+    versionPolicyIntention := Compatibility.None, // TODO Change to `Compatibility.BinaryAndSourceCompatible` after the first release
     scalaModuleMimaPreviousVersion := None,
     scalacOptions ++= Seq("-deprecation", "-feature", "-Werror"),
     libraryDependencies ++= Seq(

--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,7 @@ verPat="[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9-]+)?"
 tagPat="^v$verPat(#.*)?$"
 
 if [[ "$TRAVIS_TAG" =~ $tagPat ]]; then
+  versionCheckTask="versionCheck"
   releaseTask="ci-release"
   if ! isReleaseJob; then
     echo "Not releasing on Java $ADOPTOPENJDK with Scala $TRAVIS_SCALA_VERSION"
@@ -50,4 +51,4 @@ export CI_SNAPSHOT_RELEASE="${projectPrefix}publish"
 # for now, until we're confident in the new release scripts, just close the staging repo.
 export CI_SONATYPE_RELEASE="; sonatypePrepare; sonatypeBundleUpload; sonatypeClose"
 
-sbt clean ${projectPrefix}test ${projectPrefix}publishLocal $releaseTask
+sbt clean ${projectPrefix}test versionPolicyCheck ${projectPrefix}publishLocal $versionCheckTask $releaseTask

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
 addSbtPlugin("org.scala-lang.modules" % "sbt-scala-module" % "2.2.4")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "1.0.1")


### PR DESCRIPTION
Add sbt-version-policy to handle `versionScheme`.

For now, there are no compatibility guarantees since there has been no release.

Fixes #72, Fixes #15